### PR TITLE
update to 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.5.0" %}
+{% set version = "3.6.0" %}
 
 package:
   name: selenium
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/selenium/selenium-{{ version }}.tar.gz
-  sha256: 267418f5fde1a4f8c180e5b8f45bd57c6d45b1f7d8fa5ad699a48e9a98fa79a3
+  sha256: 9563021c5cba084041e13c218eb531d9c6920dcfa0ba1024bb5bf2b6c0df1797
 
 build:
   number: 0


### PR DESCRIPTION
```
Selenium 3.6.0

* Fix package name in python webelement module (#4670)
* Fix python driver examples (#3872)
* No need to multiply pause by 1000
* Add pause to action chains
* only check for proxyType once
* lowercase proxy type for w3c payload in python #4574
* guarding against null return value from find_elements in python #4555
* remove unnecessary pytest marking, address flake8 issues
* allow IE WebDriver to accept IE Options
* add IE Options class
* convert OSS capabilities to W3C equivalent for W3C payload
* Add Safari to API docs
```