### PR TITLE
add selenium-manager dependency from conda-forge

### DIFF
--- a/recipe/0000-find-manager-on-path.diff
+++ b/recipe/0000-find-manager-on-path.diff
@@ -1,0 +1,26 @@
+diff --git a/selenium/webdriver/common/selenium_manager.py b/selenium/webdriver/common/selenium_manager.py
+index d62ffaa..f78f60a 100644
+--- a/selenium/webdriver/common/selenium_manager.py
++++ b/selenium/webdriver/common/selenium_manager.py
+@@ -39,19 +39,8 @@ class SeleniumManager:
+ 
+         :Returns: The Selenium Manager executable location
+         """
+-        platform = sys.platform
+-
+-        dirs = {
+-            "darwin": "macos",
+-            "win32": "windows",
+-            "cygwin": "windows",
+-        }
+-
+-        directory = dirs.get(platform) if dirs.get(platform) else platform
+-
+-        file = "selenium-manager.exe" if directory == "windows" else "selenium-manager"
+-
+-        path = Path(__file__).parent.joinpath(directory, file)
++        import shutil
++        path = Path(shutil.which("selenium-manager") or shutil.which("selenium-manager.exe"))
+ 
+         if not path.is_file():
+             raise WebDriverException(f"Unable to obtain working Selenium Manager binary; {path}")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   - url: https://pypi.io/packages/source/s/selenium/selenium-{{ version }}.tar.gz
     sha256: 9f9a5ed586280a3594f7461eb1d9dab3eac9d91e28572f365e9b98d9d03e02b5
+    patches:
+      - 0000-find-manager-on-path.diff
   - fn: LICENSE-selenium-{{ version }}
     url:
       - https://raw.githubusercontent.com/SeleniumHQ/selenium/selenium-{{ version }}-python/LICENSE
@@ -20,7 +22,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
@@ -28,11 +30,12 @@ requirements:
     - python >=3.7
     - pip
   run:
+    - certifi >=2021.10.8
     - python >=3.7
+    - selenium-manager {{ version.split('.')[:2] | join('.') }}.*
     - trio >=0.17,<1.dev0
     - trio-websocket >=0.9,<1.dev0
     - urllib3 >=1.26,<3
-    - certifi >=2021.10.8
 test:
   requires:
     - pip
@@ -51,6 +54,7 @@ test:
     - selenium.webdriver.support
   commands:
     - pip check
+    - python -c "from selenium.webdriver.common.selenium_manager import SeleniumManager; assert SeleniumManager.get_binary().exists()"
 
 about:
   home: https://www.selenium.dev


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

References:
- fixes #63

Alternatives:
- do binary re-packaging of the upstream pre-built binaries?